### PR TITLE
Keybind to real-time voice dictation in Omarchy

### DIFF
--- a/PR-README.md
+++ b/PR-README.md
@@ -1,0 +1,11 @@
+This PR proposes built-in dictation.
+
+Inspired by [thePrimeagen's stream]() and their Cursor pedal, I wanted to see if there was an easy way to get voice dictation into an Omarchy keybind. I found nerd-dictation, installed, ydotool, and after a bit of debugging it just worked.
+
+Typing a long set of instructions into OpenCode or Cursor can get annoying, and I find myself often giving sub-par instructions just because I don't want to type a novel into each prompt... but now I can just speak it.
+
+Proposing this PR in case @dhh and others in the Omarchy community want to integrate this functionality into the out of the box Omarchy experience. I have not yet tested this on a fresh install, but I believe that all of the necessary configuration has been added. If anybody has a machine they don't mind hard-refreshing with a fresh Arch install, a test would be greatly appreciated. 
+
+It leverages [nerd-dictation](https://github.com/ideasman42/nerd-dictation) to perform voice to text transcrtiption with a small local model downloaded on OS install at `~/.config`, uses built-in `parec` for audio recording, and an added dependency `ydotool` to simulate input on the cursor with Wayland. This is added to the hypr autostart to launch the input emulation daemon in the background, but this could be optimized in the future.
+
+

--- a/bin/omarchy-dictation
+++ b/bin/omarchy-dictation
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Voice dictation control script for Hyprland
+# Hold SUPER SHIFT F to start record, press again to stop and submit (ENTER)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID_FILE="/tmp/voice-dictation.pid"
+START_TIME_FILE="/tmp/voice-dictation-start.time"
+
+# Notification function (mako-specific)
+notify() {
+  local message="$1"
+  local icon="$2"
+  notify-send "Voice Dictation" "$message" -i "$icon" -t 1500 -a "Voice Dictation"
+}
+
+case "$1" in
+"start")
+  # Record start time for 1-second delay
+  echo "$(date +%s)" >"$START_TIME_FILE"
+
+  # Start recording after O.1 second delay
+  (
+    sleep 0.1
+    # Check if start time file still exists (means not yet released)
+    if [[ -f "$START_TIME_FILE" ]]; then
+      ~/.config/nerd-dictation/nerd-dictation begin --simulate-input-tool=YDOTOOL &
+      echo $! >"$PID_FILE"
+      notify "Recording started 🎤" "audio-input-microphone"
+    fi
+  ) &
+  ;;
+
+"stop")
+  # Small delay to ensure clean transition
+  sleep 0.1
+
+  # Remove start time file to prevent late start
+  rm -f "$START_TIME_FILE"
+
+  # Stop recording if active
+  if [[ -f "$PID_FILE" ]]; then
+    PID=$(cat "$PID_FILE")
+    if kill -0 "$PID" 2>/dev/null; then
+      ~/.config/nerd-dictation/nerd-dictation end
+      kill "$PID" 2>/dev/null
+      rm -f "$PID_FILE"
+      notify "Recording stopped ✍️" "text-x-generic"
+
+      # Submit immediately with enter
+      sleep 0.3
+      ydotool key 28:1 28:0
+    fi
+  fi
+  ;;
+
+*)
+  echo "Usage: $0 {start|stop}"
+  exit 1
+  ;;
+esac

--- a/bin/omarchy-dictation
+++ b/bin/omarchy-dictation
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Voice dictation control script for Hyprland
-# Hold SUPER SHIFT F to start record, press again to stop and submit (ENTER)
+# Hold CTRL ALT, J to start record, press again to stop and submit (ENTER)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PID_FILE="/tmp/voice-dictation.pid"

--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -47,6 +47,7 @@ install_node() {
 case "$1" in
 ruby)
   echo -e "Installing Ruby on Rails...\n"
+  omarchy-pkg-add libyaml
   mise use --global ruby@latest
   mise settings add idiomatic_version_file_enable_tools ruby
   mise x ruby -- gem install rails --no-document

--- a/config/hypr/autostart.conf
+++ b/config/hypr/autostart.conf
@@ -1,2 +1,5 @@
+# Start ydotoold background daemon for voice dictation
+exec-once = ydotoold
+
 # Extra autostart processes
 # exec-once = uwsm app -- my-service

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -27,8 +27,8 @@ bindd = SUPER, X, X, exec, omarchy-launch-webapp "https://x.com/"
 bindd = SUPER SHIFT, X, X Post, exec, omarchy-launch-webapp "https://x.com/compose/post"
 
 # Map voice dictation - slight hold to start, press to stop and ENTER
-binddo = SUPER SHIFT, F, Start Dictation, exec, $dictation start
-bindd = SUPER SHIFT, F, Stop Dictation, exec, $dictation stop
+binddo = CTRL ALT, J, Start Dictation, exec, $dictation start
+bindd = CTRL ALT, J, Stop Dictation, exec, $dictation stop
 
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, SPACE

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -1,6 +1,7 @@
 # Application bindings
 $terminal = uwsm app -- $TERMINAL
 $browser = omarchy-launch-browser
+$dictation = omarchy-dictation
 
 bindd = SUPER, return, Terminal, exec, $terminal --working-directory="$(omarchy-cmd-terminal-cwd)"
 bindd = SUPER, F, File manager, exec, uwsm app -- nautilus --new-window
@@ -24,6 +25,10 @@ bindd = SUPER SHIFT, G, WhatsApp, exec, omarchy-launch-or-focus-webapp WhatsApp 
 bindd = SUPER ALT, G, Google Messages, exec, omarchy-launch-or-focus-webapp "Google Messages" "https://messages.google.com/web/conversations"
 bindd = SUPER, X, X, exec, omarchy-launch-webapp "https://x.com/"
 bindd = SUPER SHIFT, X, X Post, exec, omarchy-launch-webapp "https://x.com/compose/post"
+
+# Map voice dictation - slight hold to start, press to stop and ENTER
+binddo = SUPER SHIFT, F, Start Dictation, exec, $dictation start
+bindd = SUPER SHIFT, F, Stop Dictation, exec, $dictation stop
 
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, SPACE

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -15,6 +15,7 @@ run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/sudoless-asdcontrol.sh
+run_logged $OMARCHY_INSTALL/config/install-nerd-dictation.sh
 run_logged $OMARCHY_INSTALL/config/hardware/network.sh
 run_logged $OMARCHY_INSTALL/config/hardware/set-wireless-regdom.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-fkeys.sh

--- a/install/config/install-nerd-dictation.sh
+++ b/install/config/install-nerd-dictation.sh
@@ -1,0 +1,7 @@
+# put nerd-dictation in ~/.config
+# install nerd-dictation and download local translation model
+git clone https://github.com/ideasman42/nerd-dictation.git ~/.config/nerd-dictation
+wget https://alphacephei.com/kaldi/models/vosk-model-small-en-us-0.15.zip
+mv vosk-model-small-en-us-0.15.zip ~/.config/nerd-dictation
+unzip ~/.config/nerd-dictation/vosk-model-small-en-us-0.15.zip
+mv ~/.config/nerd-dictation/vosk-model-small-en-us-0.15 ~/.config/nerd-dictation/model

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -89,6 +89,7 @@ power-profiles-daemon
 python-gobject
 python-poetry-core
 python-terminaltexteffects
+python-vosk
 qt5-wayland
 ripgrep
 satty

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -128,4 +128,5 @@ xmlstarlet
 xournalpp
 yaru-icon-theme
 yay
+ydotool
 zoxide


### PR DESCRIPTION
This PR proposes built-in dictation to Omarchy.

Inspired by [@ThePrimeagen 's stream](https://www.youtube.com/live/6V_NrgpPU_c?si=7Zaz38L1Bh74PZAw) and their talk to Cursor pedal, I wanted to see if there was an easy way to get voice dictation into an Omarchy keybind. I found [nerd-dictation](https://github.com/ideasman42/nerd-dictation/tree/main) by @ideasman42, installed ydotool, and after a bit of debugging it just worked.

Typing a long set of instructions into OpenCode or Cursor can get annoying, and I find myself often giving sub-par instructions just because I don't want to type a novel into each prompt... but now I can just speak it into my mic triggered by a hypr keybind.

Proposing this PR in case @dhh and others in the Omarchy community want to integrate this functionality into the out of the box Omarchy experience. I have not yet tested this on a fresh install, but I believe that all of the necessary configuration has been added. If anybody has a machine they don't mind hard-refreshing with a fresh Arch install, a test would be greatly appreciated. 

It leverages [nerd-dictation](https://github.com/ideasman42/nerd-dictation) to perform voice to text transcription with a small local model downloaded on OS install at `~/.config/nerd-dictation`, uses built-in `parec` for audio recording, and an added dependency `ydotool` to simulate input on the cursor with Wayland. This is added to the hypr autostart to launch the input emulation daemon in the background, but this could be optimized in the future to only launch the daemon on dictation. Notifications are sent via mako when recording begins and stops.

https://github.com/user-attachments/assets/7e045c68-6baf-41a7-9a1d-db3afa18b3ea
