### PR TITLE
Fix: Allow passing flags/arguments to omarchy-launch-or-focus-webapp script

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -47,6 +47,7 @@ install_node() {
 case "$1" in
 ruby)
   echo -e "Installing Ruby on Rails...\n"
+  omarchy-pkg-add libyaml
   mise use --global ruby@latest
   mise settings add idiomatic_version_file_enable_tools ruby
   mise x ruby -- gem install rails --no-document

--- a/bin/omarchy-launch-or-focus-webapp
+++ b/bin/omarchy-launch-or-focus-webapp
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 if (($# == 0)); then
-  echo "Usage: omarchy-launch-or-focus-webapp [window-pattern] [url]"
+  echo "Usage: omarchy-launch-or-focus-webapp [window-pattern] [url-and-flags...]"
   exit 1
 fi
 
-exec omarchy-launch-or-focus "$1" "omarchy-launch-webapp '$2'"
+WINDOW_PATTERN="$1"
+shift
+LAUNCH_COMMAND="omarchy-launch-webapp $@"
+
+exec omarchy-launch-or-focus "$WINDOW_PATTERN" "$LAUNCH_COMMAND"


### PR DESCRIPTION
PR viene de repo [basecamp/omarchy](https://github.com/basecamp/omarchy) numero #[1980](https://github.com/basecamp/omarchy/pull/1980) creado por [@meirdick](https://github.com/meirdick).\n\nWhat it solves: 
This change addresses the reported issue where the omarchy-launch-or-focus-webapp script failed to correctly process and pass additional flags, such as --profile-directory, to the underlying web app launcher. This resulted in web apps not opening with the intended user profile or configuration. 

How it works: The script is modified to use shift to correctly separate the [window-pattern] from the subsequent arguments ([url] [flags...]). It then passes all remaining arguments as the single launch command to omarchy-launch-or-focus. 

Related Issue: Closes #1977