### PR TITLE
Fix Tailscale split DNS compatibility

### DIFF
--- a/install/config/hardware/printer.sh
+++ b/install/config/hardware/printer.sh
@@ -6,7 +6,7 @@ echo -e "[Resolve]\nMulticastDNS=no" | sudo tee /etc/systemd/resolved.conf.d/10-
 chrootable_systemctl_enable avahi-daemon.service
 
 # Enable mDNS resolution for .local domains
-sudo sed -i 's/^hosts:.*/hosts: mymachines mdns_minimal [NOTFOUND=return] resolve [!UNAVAIL=return] files myhostname dns/' /etc/nsswitch.conf
+sudo sed -i 's/^hosts:.*/hosts: mymachines mdns_minimal [NOTFOUND=return] resolve files myhostname dns/' /etc/nsswitch.conf
 
 # Enable automatically adding remote printers
 if ! grep -q '^CreateRemotePrinters Yes' /etc/cups/cups-browsed.conf; then

--- a/migrations/1757361128.sh
+++ b/migrations/1757361128.sh
@@ -2,6 +2,6 @@ echo "Enable mDNS resolution for existing Avahi installations"
 
 if systemctl is-enabled avahi-daemon.service >/dev/null 2>&1; then
   if ! grep -q "mdns_minimal" /etc/nsswitch.conf; then
-    sudo sed -i 's/^hosts:.*/hosts: mymachines mdns_minimal [NOTFOUND=return] resolve [!UNAVAIL=return] files myhostname dns/' /etc/nsswitch.conf
+    sudo sed -i 's/^hosts:.*/hosts: mymachines mdns_minimal [NOTFOUND=return] resolve files myhostname dns/' /etc/nsswitch.conf
   fi
 fi

--- a/migrations/1758562032.sh
+++ b/migrations/1758562032.sh
@@ -1,0 +1,5 @@
+echo "Fix Tailscale split DNS compatibility by removing [!UNAVAIL=return] from nsswitch.conf"
+
+if grep -q '\[!UNAVAIL=return\]' /etc/nsswitch.conf; then
+  sudo sed -i 's/resolve \[!UNAVAIL=return\]/resolve/g' /etc/nsswitch.conf
+fi


### PR DESCRIPTION


PR viene de repo [basecamp/omarchy](https://github.com/basecamp/omarchy) numero #[1884](https://github.com/basecamp/omarchy/pull/1884) creado por [@jardahrazdera](https://github.com/jardahrazdera).

## Summary
Fixes Tailscale split DNS compatibility issues by removing `[!UNAVAIL=return]` from nsswitch.conf configuration while maintaining mDNS printer discovery functionality.

## Changes
- Updated printer setup script to use `resolve` instead of `resolve [!UNAVAIL=return]`
- Updated existing Avahi migration script  
- Added new migration to fix existing user configurations

## Background
This addresses the issue raised by @lewispb in https://github.com/basecamp/omarchy/pull/1021#issuecomment-3318650490 where the `[!UNAVAIL=return]` parameter was breaking Tailscale split DNS for multiple users at 37signals.

## Testing
- DNS resolution continues working properly
- mDNS printer discovery functionality preserved
- Migration will automatically fix existing user configurations

## Impact
- **New installs**: Will use the correct configuration from the start
- **Existing users**: Will be automatically fixed during next system update via migration
- **Tailscale users**: Split DNS will work properly without manual intervention