### PR TITLE
Add umu-launcher to Gaming Menu

### DIFF
--- a/bin/omarchy-install-umu-launcher
+++ b/bin/omarchy-install-umu-launcher
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Now pick dependencies matching your graphics card"
+sudo pacman -Syu --noconfirm umu-launcher

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -299,11 +299,12 @@ show_install_ai_menu() {
 }
 
 show_install_gaming_menu() {
-  case $(menu "Install" "  Steam\n  RetroArch [AUR]\n󰍳  Minecraft") in
+  case $(menu "Install" "  Steam\n  RetroArch [AUR]\n󰍳  Minecraft\n umu-launcher") in
   *Steam*) present_terminal omarchy-install-steam ;;
   *RetroArch*) aur_install_and_launch "RetroArch" "retroarch retroarch-assets libretro libretro-fbneo" "com.libretro.RetroArch.desktop" ;;
   *Minecraft*) aur_install_and_launch "Minecraft [AUR]" "minecraft-launcher" "minecraft-launcher" ;;
   *) show_install_menu ;;
+  *umu-launcher*) present_terminal omarchy-install-umu-launcher ;;
   esac
 }
 


### PR DESCRIPTION


PR viene de repo [basecamp/omarchy](https://github.com/basecamp/omarchy) numero #[1878](https://github.com/basecamp/omarchy/pull/1878) creado por [@R1kaB3rN](https://github.com/R1kaB3rN).

Adds [umu-launcher](https://github.com/Open-Wine-Components/umu-launcher), a tool to run non-Steam games using the same technologies as Steam, to the gaming menu. Featured in clients such as [Heroic Games Launcher](https://heroicgameslauncher.com/), [Lutris](https://lutris.net/), and [Drop](https://droposs.org/). 

Although intended to be used by clients, adding it to the gaming menu makes it available for users who get their games from non-Steam storefronts and who prefer not to install a full-blown gaming launcher to run their games, as well as for game developers who want a quick and easy way to test their games through Proton from their terminal.

To learn more:
- [Ubuntu Summit 2024 | UMU - A unified tool for easily running your games outside of Steam](https://www.youtube.com/watch?v=iuBzGked-JU&pp=ygUMdW11LWxhdW5jaGVy)
- [GitHub - Open-Wine-Components/umu-launcher](https://github.com/Open-Wine-Components/umu-launcher)
- [umu(1)](https://man.archlinux.org/man/umu.1.en)