### PR TITLE
Chromium Enable h265 videos

### DIFF
--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -1,4 +1,4 @@
 --ozone-platform=wayland
 --ozone-platform-hint=wayland
---enable-features=TouchpadOverscrollHistoryNavigation
+--enable-features=TouchpadOverscrollHistoryNavigation,AcceleratedVideoDecodeLinuxZeroCopyGL,AcceleratedVideoDecodeLinuxGL
 --load-extension=~/.local/share/omarchy/default/chromium/extensions/copy-url

--- a/migrations/1756027039.sh
+++ b/migrations/1756027039.sh
@@ -1,0 +1,3 @@
+echo "Update chromium flags to support hardware acceleration"
+
+omarchy-refresh-config chromium-flags.conf


### PR DESCRIPTION


PR viene de repo [basecamp/omarchy](https://github.com/basecamp/omarchy) numero #[1011](https://github.com/basecamp/omarchy/pull/1011) creado por [@tarekbecker](https://github.com/tarekbecker).

I noticed that chromium cannot play h265 videos. The following flags enable the HardwareAcceleration and shall improve the performance with wayland

- [Arch Wiki on Hardware Acceleration](https://wiki.archlinux.org/title/Chromium#Hardware_video_acceleration)

Please let me know, if a migration file is required for this or what else is missing.

Thanks
Tarek 