### PR TITLE
Add a keybinding to open the capture menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -95,7 +95,7 @@ show_capture_menu() {
   *Screenshot*) show_screenshot_menu ;;
   *Screenrecord*) show_screenrecord_menu ;;
   *Color*) pkill hyprpicker || hyprpicker -a ;;
-  *) show_trigger_menu ;;
+  *) back_to show_trigger_menu ;;
   esac
 }
 

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -447,6 +447,7 @@ go_to_menu() {
   *learn*) show_learn_menu ;;
   *about*) alacritty --class Omarchy -o font.size=9 -e bash -c 'fastfetch; read -n 1 -s' ;;
   *system*) show_system_menu ;;
+  *capture*) show_capture_menu ;;
   esac
 }
 

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -30,7 +30,7 @@ bindd = CTRL, F2, Apple Display brightness up, exec, omarchy-cmd-apple-display-b
 bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-display-brightness +60000
 
 # Apple Style Screencapture shortcut (Alt + Shift + 4)
-bindd = ALT SHIFT, code:13, Screen record a region, exec, omarchy-menu capture
+bindd = ALT SHIFT, code:13, Capture menu, exec, omarchy-menu capture
 
 # Screenshots
 bindd = , PRINT, Screenshot of region, exec, omarchy-cmd-screenshot

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -29,6 +29,9 @@ bindd = CTRL, F1, Apple Display brightness down, exec, omarchy-cmd-apple-display
 bindd = CTRL, F2, Apple Display brightness up, exec, omarchy-cmd-apple-display-brightness +5000
 bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-cmd-apple-display-brightness +60000
 
+# Apple Style Screencapture shortcut (Alt + Shift + 4)
+bindd = ALT SHIFT, code:13, Screen record a region, exec, omarchy-menu capture
+
 # Screenshots
 bindd = , PRINT, Screenshot of region, exec, omarchy-cmd-screenshot
 bindd = SHIFT, PRINT, Screenshot of window, exec, omarchy-cmd-screenshot window


### PR DESCRIPTION


PR viene de repo [basecamp/omarchy](https://github.com/basecamp/omarchy) numero #[1685](https://github.com/basecamp/omarchy/pull/1685) creado por [@c4software](https://github.com/c4software).

Hi,

PR that adds a keybinding (Alt + Shift + 4) to open the capture menu (Screenshot, Video capture).  